### PR TITLE
[RS-277] 스플래시 화면 출력 중 홈 버튼 > 백그라운드 이동 후, 다시 앱 실행 > 앱이 켜졌다 꺼짐을 반복 함 => 수정

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -48,13 +48,17 @@ public abstract class SplashActivity extends AppCompatActivity {
                 return;
             }
 
-            boolean isPush = getIntent() != null && getIntent().getBooleanExtra("push", false);
+            //  push notification을 통해서 진입한 경우
+            boolean isPushNotification = getIntent() != null && getIntent().getBooleanExtra("push", false);
 
-            if(isPush) {
+            //  진입 경로가 push notification or deeplink인 경우
+            boolean isExtras = getIntent() != null && getIntent().getExtras() != null;
+
+            if(isPushNotification || !isExtras) {
                 NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
             }
 
-            if (isPush && NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
+            if (isExtras && NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
                 overridePendingTransition(0, 0);
                 finish();
             }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -54,12 +54,9 @@ public abstract class SplashActivity extends AppCompatActivity {
                 NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
             }
 
-            if (NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
+            if (isPush && NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
                 overridePendingTransition(0, 0);
-
-                if(isPush) {
-                    finish();
-                }
+                finish();
             }
             return;
         }

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -48,16 +48,18 @@ public abstract class SplashActivity extends AppCompatActivity {
                 return;
             }
 
-            if( getIntent() != null) {
-                boolean isPush = getIntent().getBooleanExtra("push", false);
+            boolean isPush = getIntent() != null && getIntent().getBooleanExtra("push", false);
 
-                if( isPush ) {
-                    NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
-                }
+            if(isPush) {
+                NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();
             }
 
             if (NavigationApplication.instance.clearHostOnActivityDestroy(this)) {
                 overridePendingTransition(0, 0);
+
+                if(isPush) {
+                    finish();
+                }
             }
             return;
         }


### PR DESCRIPTION
## Description
안드로이드에서 스플래시 화면에서 백그라운드로 전환후 다시 포그라운드 진입시에 깜빡이면서 앱 진입이 안되는 이슈를 수정했습니다.

- 확인 스텝 : 스플래시 화면 -> 홈버튼을 통해 백그라운드 전환 -> 다시 앱 아이콘 실행시 정상 구동 여부 확인

https://radish.atlassian.net/browse/RS-277