### PR TITLE
[RS-277] android splash -> background 전환후 다시 앱 진입 불가 => 수정

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/SplashActivity.java
@@ -52,7 +52,7 @@ public abstract class SplashActivity extends AppCompatActivity {
             boolean isPushNotification = getIntent() != null && getIntent().getBooleanExtra("push", false);
 
             //  진입 경로가 push notification or deeplink인 경우
-            boolean isExtras = getIntent() != null && getIntent().getExtras() != null;
+            boolean isExtras = getIntent() != null && getIntent().getExtras() != null && getIntent().getExtras().getString("url") != null;
 
             if(isPushNotification || !isExtras) {
                 NavigationApplication.instance.getEventEmitter().sendAppLaunchedEvent();


### PR DESCRIPTION
## Description
- android 스플래시 화면 출력 중 홈 버튼 > 백그라운드 이동 후, 다시 앱 실행 > 앱이 켜졌다 꺼짐을 반복 함 => 수정
- pixel 기기를 제외한 타기기에서 재현되어 예외처리 추가

https://radish.atlassian.net/browse/RS-27