### PR TITLE
[NO-ISSUE] navigation-v1 event emiiter null check for android creash

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
@@ -57,41 +57,59 @@ public class EventEmitter {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, String navigatorEventId, WritableMap data) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId, data);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId, data);
+        }
     }
 
     public void sendEvent(String eventId, String navigatorEventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, WritableMap arguments) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, arguments);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, arguments);
+        }
     }
 
     public void sendEvent(String eventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, Arguments.createMap());
+        }
     }
 
     public void sendAppLaunchedEvent() {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent("RNN.appLaunched", Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent("RNN.appLaunched", Arguments.createMap());
+        }
     }
 }


### PR DESCRIPTION
Bugsnag을 통해 유입된 이슈 대응
- react-native-navigation event emitter 예외처리 추가

- https://app.bugsnag.com/radishfiction/radish/errors/5b663e68f75bad0019be5a85?filters[error.status][0]=open&filters[event.since][0]=30d

- https://github.com/wix/react-native-navigation/issues/3100 